### PR TITLE
Add celery worker support on our nanobox setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 prodceleryworkers:
 	cd contentcuration/ && celery -A contentcuration worker -l info
 
+setupdryrun:
+	nanobox evar add dry-run DJANGO_SETTINGS_MODULE=contentcuration.dry_run_settings
+
+
 collectstatic: migrate
 	python contentcuration/manage.py collectstatic --noinput
 	python contentcuration/manage.py collectstatic_js_reverse

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-prodserver: migrate collectstatic ensurecrowdinclient downloadmessages compilemessages
-	cd contentcuration/ && gunicorn contentcuration.wsgi:application --timeout=500 --error-logfile=/var/log/gunicorn-error.log --workers=3 --bind=0.0.0.0:8000 --pid=/tmp/contentcuration.pid --log-level=debug || sleep infinity
-
 prodceleryworkers:
 	cd contentcuration/ && celery -A contentcuration worker -l info
 
@@ -31,17 +28,6 @@ downloadmessages: ensurecrowdinclient makemessages
 
 compilemessages:
 	python contentcuration/manage.py compilemessages
-
-devserver:
-	cd contentcuration && python manage.py runserver --settings=contentcuration.dev_settings 0.0.0.0:8000
-
-vagrantdevserver:
-	echo "Server to run on 192.168.31.9:8000"
-	vagrant ssh -c 'cd /vagrant/contentcuration;python manage.py runserver --settings=contentcuration.dev_settings 0.0.0.0:8000;cd -;'
-
-vagrantceleryworkers:
-	echo "Starting up celery workers"
-	vagrant ssh -c 'cd /vagrant/contentcuration;DJANGO_SETTINGS_MODULE=contentcuration.dev_settings celery -A contentcuration worker -l info;cd -;'
 
 # When using apidocs, this should clean out all modules
 clean-docs:

--- a/boxfile.yml
+++ b/boxfile.yml
@@ -51,6 +51,19 @@ web.main:
       - contentworkshop_content/
 
 
+worker.publishing:
+  start:
+    main: celery -A contentcuration worker -l info
+
+  cwd: 
+    main: contentcuration
+
+
+  network_dirs:
+    data.storage:
+      - contentworkshop_content/
+
+
 deploy.config:
   before_live:
     web.main:

--- a/boxfile.yml
+++ b/boxfile.yml
@@ -31,6 +31,9 @@ data.db:
 data.storage:
   image: nanobox/unfs:0.9
 
+data.redis:
+  image: nanobox/redis:4.0
+
 
 web.main:
   start:

--- a/contentcuration/contentcuration/dry_run_settings.py
+++ b/contentcuration/contentcuration/dry_run_settings.py
@@ -1,0 +1,5 @@
+from .production_settings import *
+
+
+SITE_ID = 1
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/contentcuration/contentcuration/production_settings.py
+++ b/contentcuration/contentcuration/production_settings.py
@@ -29,7 +29,8 @@ DATABASES = {
 
 # celery settings
 BROKER_URL = os.getenv("CELERY_BROKER_URL") or BROKER_URL
-CELERY_RESULT_BACKEND = (os.getenv("CELERY_RESULT_BACKEND_URL")
+BROKER_URL = "redis://{ip}:6379".format(ip=os.getenv("DATA_REDIS_HOST"))
+CELERY_RESULT_BACKEND = ("redis://{ip}:6379".format(ip=os.getenv("DATA_REDIS_HOST"))
                          or CELERY_RESULT_BACKEND)
 CELERY_TIMEZONE = os.getenv("CELERY_TIMEZONE") or CELERY_TIMEZONE
 

--- a/contentcuration/contentcuration/templates/registration/channel_published_email.txt
+++ b/contentcuration/contentcuration/templates/registration/channel_published_email.txt
@@ -1,0 +1,20 @@
+{% load i18n %}
+
+{% autoescape off %}
+{% trans "Hello" %} {{ user.first_name }},
+
+{% blocktrans with channel_name=channel.name %}{{ channel_name }} has finished publishing! Here is the published ID (for importing this channel into Kolibri):{% endblocktrans %}
+
+{% blocktrans with channel_id=channel.id %}ID: {{ channel_id }}{% endblocktrans %}
+
+{% blocktrans with channel_name=channel.name %}Name: {{ channel_name }}{% endblocktrans %}
+
+{% trans "Thanks for using our site!" %}
+
+{% trans "The Learning Equality Team" %}
+
+
+
+{% trans "You are receiving this email because you are subscribed to this channel." %}
+
+{% endautoescape %}

--- a/contentcuration/etc/nginx.conf
+++ b/contentcuration/etc/nginx.conf
@@ -13,6 +13,7 @@ http {
     gzip_http_version 1.0;
     gzip_proxied      any;
     gzip_min_length   500;
+    client_max_body_size 1000M;
     gzip_disable      "MSIE [1-6]\.";
     gzip_types        text/plain text/xml text/css
                       text/comma-separated-values


### PR DESCRIPTION
- add redis & celery worker setup
- add some shortcuts to make setting up the dry-run environment easier
- add a new settings file that's used for dry-runs
